### PR TITLE
Add workflow to build and publish dependencies snap

### DIFF
--- a/.github/workflows/publish-on-demand.yaml
+++ b/.github/workflows/publish-on-demand.yaml
@@ -1,0 +1,46 @@
+name: Publish on demand
+on:
+  workflow_dispatch: # or manually
+
+jobs:
+  publish_amd64:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: install snapcraft
+      run: sudo snap install snapcraft --classic
+    - name: Build snap
+      continue-on-error: true
+      run: |
+        sudo snapcraft --destructive-mode --verbose
+        sudo rm -rf $HOME/.config/snapcraft
+
+    - name: Copy snapcraft logs
+      continue-on-error: true
+      run: |
+        sudo cp -r /root/.local/state/snapcraft/log/ ./
+
+    - name: Upload log artifact
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        name: snapcraft-log
+        path: log/*
+
+    - name: Publish snap
+      if: github.repository_owner == 'FreeCAD' # Do not run on forks
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      run: snapcraft upload --release=edge freecad*.snap
+
+    - name: Gather snap package name
+      run: |
+        snapArtifactPath=$(find . -type f -name *.snap)
+        echo "Snap package name is: '$snapArtifactPath'"
+        echo "snapArtifactPath=$snapArtifactPath" >> $GITHUB_ENV
+
+    - name: Upload snap package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: snap-package
+        path: ${{ env.snapArtifactPath }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: furgo-freecad-deps-core24
+name: freecad-deps-core24
 base: core24
 adopt-info: version
 summary: Dependencies for FreeCAD snaps

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: freecad-deps-core24
+name: furgo-freecad-deps-core24
 base: core24
 adopt-info: version
 summary: Dependencies for FreeCAD snaps

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
-name: freecad-deps-core20
-base: core20
+name: freecad-deps-core24
+base: core24
 adopt-info: version
 summary: Dependencies for FreeCAD snaps
 description: |
@@ -15,22 +15,26 @@ parts:
     build-packages:
       - git
     override-build: |
-      cd "${SNAPCRAFT_PROJECT_DIR}"
+      cd "${CRAFT_PROJECT_DIR}"
       git_hash=$(git rev-parse --short=8 HEAD)
-      snapcraftctl set-version "${git_hash}"
+      craftctl set version="${git_hash}"
 
   occt:
     plugin: cmake
     source: https://gitlab.com/blobfish/occt.git
-    source-branch: V7_6_3_BF
+    source-branch: V7_8_0_BF
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DUSE_TBB:BOOL=on
+      - -DCMAKE_PREFIX_PATH=${CRAFT_STAGE}/usr
+      - -DUSE_TBB:BOOL=off
       - -DUSE_VTK:BOOL=off
       - -DUSE_FREEIMAGE:BOOL=on
       - -DBUILD_RELEASE_DISABLE_EXCEPTIONS:BOOL=off
       - -DUSE_RAPIDJSON:BOOL=on
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_FIND_ROOT_PATH=$CRAFT_STAGE
+      - -D3RDPARTY_TBB_LIBRARY_DIR=$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      - -D3RDPARTY_TBBMALLOC_LIBRARY_DIR=$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
     build-packages:
       - libfreeimage-dev
       - libfreetype6-dev
@@ -39,12 +43,17 @@ parts:
       - libtbb-dev
       - libgl-dev
       - rapidjson-dev
+    stage-packages:
+      - libtbb12
+      - libtbbmalloc2
     override-build: |
-      snapcraftctl build
-      find "${SNAPCRAFT_PART_INSTALL}/usr/lib/cmake" \
+      craftctl default
+      find "${CRAFT_PART_INSTALL}/usr/lib/cmake" \
         -type f \
         -name "*.cmake" \
         -exec sed -i -e 's|\\${OCCT_INSTALL_BIN_LETTER}||g' {} \;
+    build-environment:
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib:$CRAFT_STAGE/lib/:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
     prime:
       -  -usr/share/opencascade
 
@@ -52,22 +61,23 @@ parts:
     after: [occt]
     plugin: cmake
     source: https://gitlab.onelab.info/gmsh/gmsh.git
-    source-tag: gmsh_4_10_5
+    source-tag: gmsh_4_13_1
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DCMAKE_PREFIX_PATH=${SNAPCRAFT_STAGE}/usr
+      - -DCMAKE_PREFIX_PATH=${CRAFT_STAGE}/usr
       - -DCMAKE_BUILD_TYPE=Release
       - -DENABLE_BUILD_DYNAMIC=1
       - -DENABLE_MED=0
       - -DENABLE_FLTK=0
-  
+    build-environment:
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib:$CRAFT_STAGE/lib/:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
   cleanup:
     after: [occt, gmsh]
     plugin: nil
     override-prime: |
       set -eux
       for cruft in bug lintian man; do
-        rm -rf $SNAPCRAFT_PRIME/usr/share/$cruft
+        rm -rf $CRAFT_PRIME/usr/share/$cruft
       done
-      find $SNAPCRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete
-      find $SNAPCRAFT_PRIME/usr/share -type d -empty -delete
+      find $CRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete
+      find $CRAFT_PRIME/usr/share -type d -empty -delete


### PR DESCRIPTION
- Copied workflow over from https://github.com/FreeCAD/FreeCAD-snap/blob/master/.github/workflows/publish-daily.yml and slightly modified it to not run on schedule, only on demand
- It will only work for `core24` branches, as it runs on Ubuntu 24.04
- Brings in `snapcraft.yaml` changes as well: update syntax for current Snapcraft versions, and update dependencies
- It might need the current `Publish` workflow to be disabled when merging. I don't know if that original `Publish` workflow is up-to-date and working.

## Usage

To test once merged:

1. On this repo (`FreeCAD/freecad-deps-snap`), go to the <kbd>Actions</kbd> tab
2. Select the <kbd>Publish on demand</kbd> workflow on the left panel
3. Click on the <kbd>Run workflow</kbd> dropdown on the right
4. Select the `core24` branch. This is the branch the snap will be built for and published
5. For the publish part to succeed, this repo might need the snapcraft store secrets to be set up here in GitHub, if they are not already set up (I don't have visibility on this).

![image](https://github.com/user-attachments/assets/e113796f-ea18-4602-8ac1-2678390c80d7)

Even if the publishing fails, the built snap will be created and available as an artifact on the workflow run page. The resulting snap can be manually downloaded and uploaded to the store:

1. On this repo (`FreeCAD/freecad-deps-snap`), go to the <kbd>Actions</kbd> tab
2. Select the <kbd>Publish on demand</kbd> workflow on the left panel
3. Click on the successful <kbd>Publish on demand</kbd> workflow run on the right
4. Download the `snap-package` artifact at the bottom of the page
5. On your local machine, unzip the downloaded `snap-package`
6. Manually upload to the store according to the [publishing instructions](https://snapcraft.io/docs/releasing-your-app). E.g. `snapcraft upload --release=edge freecad-deps-snap_amd64.snap`

![image](https://github.com/user-attachments/assets/f59b24b4-90bb-43c0-8ac7-082ae6b80137)
