### PR TITLE
Refactor GitHub publish on demand workflow for multi-architecture builds

### DIFF
--- a/.github/workflows/publish-on-demand.yaml
+++ b/.github/workflows/publish-on-demand.yaml
@@ -1,46 +1,57 @@
 name: Publish on demand
+
 on:
-  workflow_dispatch: # or manually
+  workflow_dispatch: # Allows manual triggering
+
+env:
+  # Log path location for containerized builds
+  LOG_PATH: /home/runner/.local/state/snapcraft/log/
 
 jobs:
-  publish_amd64:
-    runs-on: ubuntu-24.04
+  build-and-publish:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm64
+
+    runs-on: ${{ matrix.runner }}
+
     steps:
-    - uses: actions/checkout@v4
-    - name: install snapcraft
-      run: sudo snap install snapcraft --classic
-    - name: Build snap
-      continue-on-error: true
-      run: |
-        sudo snapcraft --destructive-mode --verbose
-        sudo rm -rf $HOME/.config/snapcraft
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Copy snapcraft logs
-      continue-on-error: true
-      run: |
-        sudo cp -r /root/.local/state/snapcraft/log/ ./
+      - name: Build snap in isolated container
+        id: build
+        uses: canonical/action-build@v1
+        with:
+          snapcraft-channel: latest/stable
+          snapcraft-args: --verbose
 
-    - name: Upload log artifact
-      continue-on-error: true
-      uses: actions/upload-artifact@v4
-      with:
-        name: snapcraft-log
-        path: log/*
+      - name: Publish snap to Snap Store
+        # Conditions: only on success, and not on forks
+        if: steps.build.outcome == 'success' && github.repository_owner == 'FreeCAD'
+        uses: canonical/action-publish@v1
+        with:
+          # The action's output provides the snap path directly
+          snap: ${{ steps.build.outputs.snap }}
+          release: edge
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
 
-    - name: Publish snap
-      if: github.repository_owner == 'FreeCAD' # Do not run on forks
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-      run: snapcraft upload --release=edge freecad*.snap
+      - name: Upload snap package artifact
+        if: steps.build.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: snap-package-${{ matrix.arch }}
+          path: ${{ steps.build.outputs.snap }}
 
-    - name: Gather snap package name
-      run: |
-        snapArtifactPath=$(find . -type f -name *.snap)
-        echo "Snap package name is: '$snapArtifactPath'"
-        echo "snapArtifactPath=$snapArtifactPath" >> $GITHUB_ENV
-
-    - name: Upload snap package artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: snap-package
-        path: ${{ env.snapArtifactPath }}
+      - name: Upload log artifact
+        # Ensure this runs even if the build fails
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapcraft-log-${{ matrix.arch }}
+          path: ${{ env.LOG_PATH }}/*


### PR DESCRIPTION
Next iteration from https://github.com/FreeCAD/freecad-deps-snap/pull/4:

- Simplify steps
- Improve logic to upload logs unconditionally
- Improve logic to report success/failure
- Include arm64 builds