### PR TITLE
Fix runner configuration for arm64 architecture

### DIFF
--- a/.github/workflows/publish-on-demand.yaml
+++ b/.github/workflows/publish-on-demand.yaml
@@ -15,7 +15,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-24.04
           - arch: arm64
-            runner: ubuntu-24.04-arm64
+            runner: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
As per https://docs.github.com/en/actions/concepts/runners/github-hosted-runners#runner-images and https://github.com/actions/partner-runner-images